### PR TITLE
Add dataTransfer.setData() for Firefox compatibility.

### DIFF
--- a/lib/html5-sortable.js
+++ b/lib/html5-sortable.js
@@ -37,6 +37,7 @@ sortable_app.directive('htmlSortable', function($parse,$timeout, $log, $window) 
         }
 
         sortable.is_handle  = false;
+        e.dataTransfer.setData('text/plain', '');
         e.dataTransfer.effectAllowed = 'move';
         
          $window['drag_source'] = this;


### PR DESCRIPTION
This fixes a bug where sortable does not work with Firefox. Firefox requires a call to dataTransfer.setData() in order to use drag and drop. See http://stackoverflow.com/questions/18269677/drag-and-drop-not-working-in-firefox
