### PR TITLE
support minification

### DIFF
--- a/lib/html5-sortable.js
+++ b/lib/html5-sortable.js
@@ -6,7 +6,7 @@
 */
 
 var sortable_app = angular.module('html5.sortable', []);
-sortable_app.directive('htmlSortable', function($parse,$timeout, $log, $window) {
+sortable_app.directive('htmlSortable', ["$parse", "$timeout", "$log", "$window", function($parse, $timeout, $log, $window) {
 
   return {
     restrict: 'A',
@@ -288,4 +288,4 @@ sortable_app.directive('htmlSortable', function($parse,$timeout, $log, $window) 
       }
     }
   };
-});
+}]);


### PR DESCRIPTION
After the minification Angular cannot deduce the names of dependencies from the names of parameters (they are minified). Angular also offers an official way to work around this. It can be applied automatically with ng-annotate, but this requires an extra dependency and build slowness. 

I propose to include names of dependencies in the source, as per Angular documentation.