### PR TITLE
Update html5-sortable.js to work with HTML5 Drag and Drop Shim

### DIFF
--- a/lib/html5-sortable.js
+++ b/lib/html5-sortable.js
@@ -73,6 +73,7 @@ sortable_app.directive('htmlSortable', ["$parse", "$timeout", "$log", "$window",
       };
 
       sortable.handleDragEnter = function(e) {
+        e.preventDefault(); // Allows us to drop on mobile with HTML5 Drag and Drop Shim
         if ( !this.classList.contains('over') ){
           this.classList.add('over');
         }


### PR DESCRIPTION
Add preventDefault on handleDragEnter to Allows us to drop on mobile with HTML5 Drag and Drop Shim.

I couldn't see any way to add this in the options but found it worked when I added it to your js file. Obviously I would have preferred to add this in the AngularJS app but couldn't find a way to do it.

I don't see any loss of function when adding this code.